### PR TITLE
`feat: Update Static Serving with Fallback and Embed FS Subdirectories`

### DIFF
--- a/cmd/examples/02_router_features/06_serve_static_with_fallback/main.go
+++ b/cmd/examples/02_router_features/06_serve_static_with_fallback/main.go
@@ -10,6 +10,9 @@ import (
 //go:embed framework_assets/*
 var frameworkAssets embed.FS
 
+//go:embed project/static/*
+var projectStatic embed.FS
+
 // This example demonstrates how to serve static files with fallback in Lokstra:
 // 1. Serving files from multiple sources with fallback priority
 // 2. Project assets override framework assets
@@ -18,20 +21,15 @@ func main() {
 	ctx := lokstra.NewGlobalRegistrationContext()
 	app := lokstra.NewApp(ctx, "static-fallback-app", ":8080")
 
-	// Create sub-filesystem for framework_assets
-	// frameworkSubFS, err := fs.Sub(frameworkAssets, "framework_assets")
-	// if err != nil {
-	// 	panic(err)
-	// }
-
 	// Serve static files with fallback:
 	// 1. First try project/assets (project-specific overrides)
 	// 2. Then try project/static (main project assets)
 	// 3. Finally try frameworkAssets embed.FS (framework default assets)
 	app.MountStaticWithFallback("/static",
 		http.Dir("./project/assets"), // Project overrides (highest priority)
-		http.Dir("./project/static"), // Project assets
-		frameworkAssets,              // Framework default assets (lowest priority)
+		// http.Dir("./project/static"), // Project assets
+		projectStatic,   // Project assets (dengan sub-filesystem)
+		frameworkAssets, // Framework default assets (lowest priority)
 	)
 
 	// Alternative: Using string paths instead of http.Dir

--- a/common/file_system/file_system.go
+++ b/common/file_system/file_system.go
@@ -1,0 +1,66 @@
+package file_system
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+type FSWithSubFS struct {
+	fs.FS
+	SubFS string
+}
+
+func findCommonFolder(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	if len(paths) == 1 {
+		idx := strings.LastIndex(paths[0], "/")
+		if idx == -1 {
+			return ""
+		}
+		return paths[0][:idx]
+	}
+
+	splitPaths := make([][]string, len(paths))
+	for i, p := range paths {
+		splitPaths[i] = strings.Split(p, "/")
+	}
+	var common []string
+	for i := 0; ; i++ {
+		var folder string
+		for j, sp := range splitPaths {
+			if i >= len(sp) {
+				return strings.Join(common, "/")
+			}
+			if j == 0 {
+				folder = sp[i]
+			} else if sp[i] != folder {
+				return strings.Join(common, "/")
+			}
+		}
+		common = append(common, folder)
+	}
+}
+
+// SubFirstCommonFolder takes an fs.FS and returns a sub fs.FS that starts from the first common folder
+// If no common folder is found, it returns an error
+func SubFirstCommonFolder(fsys fs.FS) (fs.FS, error) {
+	var paths []string
+	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if len(paths) == 0 {
+		return fsys, nil // No files, return original FS
+	}
+
+	commonFolder := findCommonFolder(paths)
+	if commonFolder != "" && commonFolder != "." {
+		return fs.Sub(fsys, commonFolder)
+	}
+	return nil, fmt.Errorf("no commonFolder found in FS")
+}

--- a/core/request/context.go
+++ b/core/request/context.go
@@ -29,7 +29,7 @@ func NewContext(w http.ResponseWriter, r *http.Request) (*Context, func()) {
 	return &Context{
 		Context:  ctx,
 		Response: resp,
-		Writer:   w,
+		Writer:   response.NewResponseWriterWrapper(w),
 		Request:  req,
 	}, cancel
 }

--- a/core/request/serve_file.go
+++ b/core/request/serve_file.go
@@ -1,0 +1,50 @@
+package request
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"github.com/primadi/lokstra/common/file_system"
+)
+
+func ServeFile(path any) HandlerFunc {
+	var fileSystem http.FileSystem
+
+	switch v := path.(type) {
+	case string:
+		fileSystem = http.Dir(v)
+	case http.Dir:
+		fileSystem = v
+	case file_system.FSWithSubFS:
+		subFs, err := fs.Sub(v.FS, v.SubFS)
+		if err != nil {
+			panic(err)
+		}
+		fileSystem = http.FS(subFs)
+	case embed.FS:
+		sub, err := file_system.SubFirstCommonFolder(v)
+		if err != nil {
+			panic(err)
+		}
+		fileSystem = http.FS(sub)
+	case fs.FS:
+		fileSystem = http.FS(v)
+	default:
+		panic("ServeFile: unsupported path type")
+	}
+
+	return func(ctx *Context) error {
+		p := ctx.Request.URL.Path
+		idx := strings.Index(p[1:], "/")
+		if idx == -1 {
+			http.FileServer(fileSystem).ServeHTTP(ctx.Writer, ctx.Request)
+		} else {
+			prefix := p[:idx+2]
+			http.StripPrefix(prefix, http.FileServer(fileSystem)).
+				ServeHTTP(ctx.Writer, ctx.Request)
+		}
+		return nil
+	}
+}

--- a/core/response/writter_wrapper.go
+++ b/core/response/writter_wrapper.go
@@ -1,0 +1,27 @@
+package response
+
+import "net/http"
+
+// ResponseWriterWrapper wraps http.ResponseWriter to track if WriteHeader has been called
+type ResponseWriterWrapper struct {
+	http.ResponseWriter
+	written bool
+}
+
+func NewResponseWriterWrapper(w http.ResponseWriter) *ResponseWriterWrapper {
+	return &ResponseWriterWrapper{ResponseWriter: w}
+}
+
+func (w *ResponseWriterWrapper) WriteHeader(code int) {
+	if !w.written {
+		w.ResponseWriter.WriteHeader(code)
+		w.written = true
+	}
+}
+
+func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
+	if !w.written {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(data)
+}

--- a/core/router/group_impl_test.go
+++ b/core/router/group_impl_test.go
@@ -25,7 +25,9 @@ func TestGroupImpl_BasicMethods(t *testing.T) {
 		groupMeta := group.GetMeta()
 		if groupMeta == nil {
 			t.Error("Expected meta to be available, got nil")
+			return
 		}
+
 		if groupMeta.Prefix != "/api" {
 			t.Errorf("Expected meta prefix '/api', got %s", groupMeta.Prefix)
 		}


### PR DESCRIPTION
* Update `main.go` to serve static files with fallback and embed FS subdirectories
* Update `context.go` to use `response.NewResponseWriterWrapper`
* Update